### PR TITLE
Fix linker garbage-collecting dlsym()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS = -Wall -O2 -fPIC -rdynamic -shared
-CXXFLAGS = -Wall -O2 -fPIC -rdynamic -shared
+CFLAGS = -Wall -O2 -fPIC -rdynamic -shared -Wl,--no-as-needed
+CXXFLAGS = -Wall -O2 -fPIC -rdynamic -shared -Wl,--no-as-needed
 LDFLAGS =
 
 all: ldpreload-forcerdonly.so ldpreload-forceurandom.so ldpreload-prebind.so ldpreload-unixbind.so


### PR DESCRIPTION
Compiling this on an Ubuntu 20.04 machine (with gcc 9.4.0), I get this error when running an application with the compiled module: `/bin/sh: symbol lookup error: /tmp/ldpreload/ldpreload-forceurandom.so: undefined symbol: dlsym`

I found [this old Stackoverflow post](https://stackoverflow.com/questions/17201849/g-cannot-link-to-libdl-even-with-ldl-flag) and the solution mentioned there - adding `-Wl,--no-as-needed` to the Makefile - makes it work for me. 

Not sure if this can break other stuff but it seems to be working and the error is gone, so I wanted to make this PR. Maybe you can take a look at if this is a sensible fix, I haven't really used shared objects much before.